### PR TITLE
feat(user): create user entity and persistence structure

### DIFF
--- a/src/main/java/com/yan/virtuallibrary/domain/User.java
+++ b/src/main/java/com/yan/virtuallibrary/domain/User.java
@@ -1,0 +1,48 @@
+package com.yan.virtuallibrary.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Email
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @NotBlank
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "updatedAt", nullable = true)
+    private LocalDateTime updateAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updateAt = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
Este pull request introduz uma nova entidade `User` ao código-fonte, representando os usuários no sistema e mapeando-os para a tabela `users` no banco de dados. A classe inclui campos para detalhes do usuário, validação e gerenciamento automático de timestamps.

### Criação da nova entidade:

* **Adição da classe de entidade `User`**: Criada em `com.yan.virtuallibrary.domain` com os campos `id`, `name`, `username`, `email`, `password` e timestamps (`createAt`, `updateAt`). A classe utiliza anotações JPA para persistência e restrições de validação para garantir a integridade dos dados.
* **Implementação de timestamps automáticos**: Configuração automática das datas de criação e atualização utilizando os callbacks de ciclo de vida `@PrePersist` e `@PreUpdate`.
