### PR TITLE
Add routes for user read books management

### DIFF
--- a/src/main/java/com/yan/virtuallibrary/Users/controller/UserBookController.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/controller/UserBookController.java
@@ -2,6 +2,7 @@ package com.yan.virtuallibrary.Users.controller;
 
 import com.yan.virtuallibrary.Users.dto.UserBookRequestDTO;
 import com.yan.virtuallibrary.Users.dto.UserBookResponseDTO;
+import com.yan.virtuallibrary.Users.dto.UserBookUpdateDTO;
 import com.yan.virtuallibrary.Users.service.UserBookService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,4 +24,19 @@ public class UserBookController {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
+    @GetMapping("/{id}/books")
+    public ResponseEntity<?> findAllBooks(@PathVariable Long id){
+        try {
+            var result = this.userBookService.findAllBooks(id);
+            return  ResponseEntity.ok().body(result);
+        } catch (Exception e){
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+    @PatchMapping("/{userId}/books/{bookId}")
+    public ResponseEntity<?> updateBookStatus(@PathVariable Long userId, @PathVariable Long bookId, @RequestBody UserBookUpdateDTO userBookUpdateDTO){
+        var result = userBookService.updateBookStatus(userId, bookId, userBookUpdateDTO);
+        return ResponseEntity.ok().body(result);
+    }
 }
+

--- a/src/main/java/com/yan/virtuallibrary/Users/controller/UserController.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.yan.virtuallibrary.Users.controller;
 
-import com.yan.virtuallibrary.Users.dto.UserBookRequestDTO;
-import com.yan.virtuallibrary.Users.dto.UserBookResponseDTO;
+import com.yan.virtuallibrary.Users.domain.entities.UserEntity;
 import com.yan.virtuallibrary.Users.dto.UserRequestDTO;
 import com.yan.virtuallibrary.Users.dto.UserResponseDTO;
 import com.yan.virtuallibrary.Users.service.UserBookService;
@@ -9,6 +8,7 @@ import com.yan.virtuallibrary.Users.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,14 +20,10 @@ public class UserController {
     @Autowired
     private UserBookService userBookService;
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> getUserById(@PathVariable Long id){
-        try{
-            UserResponseDTO response = this.userService.getUserById(id);
-            return ResponseEntity.ok().body(response);
-        } catch (Exception e){
-        return  ResponseEntity.badRequest().body(e.getMessage());
-        }
+    @GetMapping("/me")
+    public ResponseEntity<?> getMe(@AuthenticationPrincipal UserEntity user){
+        var result = this.userService.getMe(user);
+        return ResponseEntity.ok().body(result);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/yan/virtuallibrary/Users/repository/UserBookRepository.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/repository/UserBookRepository.java
@@ -4,6 +4,11 @@ import com.yan.virtuallibrary.Users.domain.entities.UserBookEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface UserBookRepository extends JpaRepository<UserBookEntity, Long> {
+    List<UserBookEntity> findAllByUser_Id(Long id);
+    Optional<UserBookEntity> findByUser_IdAndBook_Id(Long userId, Long bookId);
 }

--- a/src/main/java/com/yan/virtuallibrary/Users/service/UserBookService.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/service/UserBookService.java
@@ -7,9 +7,12 @@ import com.yan.virtuallibrary.Users.domain.entities.UserBookEntity;
 import com.yan.virtuallibrary.Users.domain.entities.UserEntity;
 import com.yan.virtuallibrary.Users.dto.UserBookRequestDTO;
 import com.yan.virtuallibrary.Users.dto.UserBookResponseDTO;
+import com.yan.virtuallibrary.Users.dto.UserBookUpdateDTO;
 import com.yan.virtuallibrary.Users.repository.UserBookRepository;
 import com.yan.virtuallibrary.Users.repository.UserRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class UserBookService {
@@ -62,6 +65,64 @@ public class UserBookService {
                 savedUserBook.getUpdated_at()
         );
 
+    }
+    
+    public List<UserBookResponseDTO> findAllBooks(Long id){
+        return userBookRepository.findAllByUser_Id(id).stream()
+                .map(userBookEntity -> new UserBookResponseDTO(
+                        userBookEntity.getId(),
+                        new BookResponseDTO(
+                                userBookEntity.getBook().getId(),
+                                userBookEntity.getBook().getExternalId(),
+                                userBookEntity.getBook().getTitle(),
+                                userBookEntity.getBook().getAuthor(),
+                                userBookEntity.getBook().getPublisher(),
+                                userBookEntity.getBook().getIsbn(),
+                                userBookEntity.getBook().getSynopsis(),
+                                userBookEntity.getBook().getGenre(),
+                                userBookEntity.getBook().getCoverUrl(),
+                                userBookEntity.getBook().getSource().name()
+                        ),
+                        userBookEntity.getReadStatus(),
+                        userBookEntity.getReadFormat(),
+                        userBookEntity.getStartedAt(),
+                        userBookEntity.getFinishedAt(),
+                        userBookEntity.getCreated_at(),
+                        userBookEntity.getUpdated_at()
+                ))
+                .toList();
+    }
+
+    public UserBookResponseDTO updateBookStatus(Long userId, Long bookId, UserBookUpdateDTO userBookUpdateDTO){
+        UserBookEntity userBook = userBookRepository.findByUser_IdAndBook_Id(userId, bookId).orElseThrow(() -> new RuntimeException("UserBook not found"));
+        if(userBookUpdateDTO.readStatus() != null){ userBook.setReadStatus(userBookUpdateDTO.readStatus());}
+        if(userBookUpdateDTO.readFormat() != null){ userBook.setReadFormat(userBookUpdateDTO.readFormat());}
+        if(userBookUpdateDTO.startedAt() != null){ userBook.setStartedAt(userBookUpdateDTO.startedAt());}
+        if(userBookUpdateDTO.finishedAt() != null){ userBook.setFinishedAt(userBookUpdateDTO.finishedAt());}
+
+        UserBookEntity updatedUserBook = userBookRepository.save(userBook);
+
+        return new UserBookResponseDTO(
+                updatedUserBook.getId(),
+                new BookResponseDTO(
+                        updatedUserBook.getBook().getId(),
+                        updatedUserBook.getBook().getExternalId(),
+                        updatedUserBook.getBook().getTitle(),
+                        updatedUserBook.getBook().getAuthor(),
+                        updatedUserBook.getBook().getPublisher(),
+                        updatedUserBook.getBook().getIsbn(),
+                        updatedUserBook.getBook().getSynopsis(),
+                        updatedUserBook.getBook().getGenre(),
+                        updatedUserBook.getBook().getCoverUrl(),
+                        updatedUserBook.getBook().getSource().name()
+                ),
+                updatedUserBook.getReadStatus(),
+                updatedUserBook.getReadFormat(),
+                updatedUserBook.getStartedAt(),
+                updatedUserBook.getFinishedAt(),
+                updatedUserBook.getCreated_at(),
+                updatedUserBook.getUpdated_at()
+        );
     }
 
 }

--- a/src/main/java/com/yan/virtuallibrary/Users/service/UserService.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/service/UserService.java
@@ -1,11 +1,13 @@
 package com.yan.virtuallibrary.Users.service;
 
+import com.yan.virtuallibrary.Users.domain.entities.UserBookEntity;
 import com.yan.virtuallibrary.Users.domain.entities.UserEntity;
 import com.yan.virtuallibrary.Users.dto.UserRequestDTO;
 import com.yan.virtuallibrary.Users.dto.UserResponseDTO;
 import com.yan.virtuallibrary.Users.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -77,6 +79,8 @@ public class UserService {
         UserEntity user = userRepository.findById(id).orElseThrow(() -> new RuntimeException("User not found"));
         userRepository.delete(user);
     }
+
+
 }
 
 

--- a/src/main/java/com/yan/virtuallibrary/Users/service/UserService.java
+++ b/src/main/java/com/yan/virtuallibrary/Users/service/UserService.java
@@ -1,14 +1,10 @@
 package com.yan.virtuallibrary.Users.service;
 
-import com.yan.virtuallibrary.Users.domain.entities.UserBookEntity;
 import com.yan.virtuallibrary.Users.domain.entities.UserEntity;
 import com.yan.virtuallibrary.Users.dto.UserRequestDTO;
 import com.yan.virtuallibrary.Users.dto.UserResponseDTO;
 import com.yan.virtuallibrary.Users.repository.UserRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 public class UserService {
@@ -41,17 +37,13 @@ public class UserService {
                 savedUser.getRole().name());
     }
 
-    public UserResponseDTO getUserById(Long id) {
-       UserEntity user = userRepository.findById(id).orElseThrow(() -> new RuntimeException("User not found"));
-
-        return new UserResponseDTO(
-                user.getId(),
-                user.getName(),
-                user.getUsername(),
-                user.getEmail(),
-                user.getRole().name());
-
-
+    public UserResponseDTO getMe(UserEntity user) {
+      return new UserResponseDTO(
+              user.getId(),
+              user.getName(),
+              user.getUsername(),
+              user.getEmail(),
+              user.getRole().name());
     }
 
     public UserResponseDTO updateUser(Long id, UserRequestDTO userRequestDTO) {

--- a/src/main/java/com/yan/virtuallibrary/security/SecurityConfig.java
+++ b/src/main/java/com/yan/virtuallibrary/security/SecurityConfig.java
@@ -29,6 +29,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/auth/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/books/").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/books/{id}").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/books/{id}").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
This pull request adds new functionality for managing user books, including the ability to retrieve all books for a user and update the status of a user's book. It introduces corresponding endpoints in the controller, new repository methods, and service logic to support these features.

**User Book Management Enhancements:**

* Added a `GET /{id}/books` endpoint in `UserBookController` to retrieve all books associated with a user.
* Added a `PATCH /{userId}/books/{bookId}` endpoint in `UserBookController` to update the read status, format, and dates for a user's book.
* Implemented `findAllBooks(Long id)` and `updateBookStatus(Long userId, Long bookId, UserBookUpdateDTO)` methods in `UserBookService` to handle the new controller endpoints.
* Added repository methods `findAllByUser_Id(Long id)` and `findByUser_IdAndBook_Id(Long userId, Long bookId)` in `UserBookRepository` to support efficient queries for user books.

**Other Minor Changes:**

* Updated import statements to include new DTOs and entity classes as needed for the new functionality. [[1]](diffhunk://#diff-ba35d90c6a413c06911f0a0d1004b2ec390f2989652688bf0ba6c3c9b122e060R5) [[2]](diffhunk://#diff-6ff4e0c18ade4dfe4db90a5164f45dac26ce999eeb87e436beb9a7a77e357341R10-R16) [[3]](diffhunk://#diff-e18bafa2623a91032dce68efb9e3ce47e88c27f5733a360c1d1198066f92f82eR3-R10)